### PR TITLE
fix: `/getting-started-cli/installation` redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
             "permanent": true
         },
         { 
-            "source": "/getting-started/installation",
+            "source": "/getting-started-cli/installation",
             "destination": "/mergestat-lite/installation",
             "permanent": true
         },


### PR DESCRIPTION
had a typo in the original URL.

Address https://github.com/mergestat/mergestat-lite/issues/328